### PR TITLE
Feat#43 accountlog/pagination

### DIFF
--- a/Kkabi_Backend/src/main/java/com/project/controller/AccountLogController.java
+++ b/Kkabi_Backend/src/main/java/com/project/controller/AccountLogController.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,9 +51,11 @@ public class AccountLogController {
 	 */
 	@GetMapping("/account-log")
 	@ApiOperation(value="내 계좌 로그 조회", notes="내역 확인 버튼을 누를 시 사용된다.")
-	public List<AccountLog> selectAccountLog(int accountId){
+	public Page<AccountLog> selectAccountLog(int accountId, Model model, Pageable page){
 		
-		List<AccountLog> accountLogList = accountLogService.selectAccoungLog(accountId);
+		Page<AccountLog> accountLogList = accountLogService.selectAccoungLog(accountId, page);
+		
+		model.addAttribute("accountLogList", accountLogList);
 		
 		return accountLogList;
 	}

--- a/Kkabi_Backend/src/main/java/com/project/repository/AccountLogRepository.java
+++ b/Kkabi_Backend/src/main/java/com/project/repository/AccountLogRepository.java
@@ -1,7 +1,9 @@
 package com.project.repository;
 
-import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,7 +11,10 @@ import org.springframework.data.repository.query.Param;
 import com.project.domain.AccountLog;
 
 public interface AccountLogRepository extends JpaRepository<AccountLog, Integer>{
+	int nowPage = 1;
+	int PAGE_COUNT = 10;
+	Pageable page = PageRequest.of((nowPage-1), PAGE_COUNT);
 	
-	@Query(value="select a from AccountLog a where a.accountList.accountId = :accountId")
-	List<AccountLog> findAllByAccountListJPQL(@Param("accountId") int accountId);
+	@Query(value="select a from AccountLog a where a.accountList.accountId = :accountId order by a.accountLogId desc")
+	Page<AccountLog> findAllByAccountListJPQL(@Param("accountId") int accountId, Pageable page);
 }

--- a/Kkabi_Backend/src/main/java/com/project/service/AccountLogService.java
+++ b/Kkabi_Backend/src/main/java/com/project/service/AccountLogService.java
@@ -2,6 +2,9 @@ package com.project.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.project.domain.AccountLog;
 
 public interface AccountLogService {
@@ -19,7 +22,7 @@ public interface AccountLogService {
 	 * 
 	 * @author awarduuu
 	 * @param accountId
-	 * @return List<AccountLog>
+	 * @return Page<AccountLog>
 	 */
-	List<AccountLog> selectAccoungLog(int accountId);
+	Page<AccountLog> selectAccoungLog(int accountId, Pageable page);
 }

--- a/Kkabi_Backend/src/main/java/com/project/service/AccountLogServiceImpl.java
+++ b/Kkabi_Backend/src/main/java/com/project/service/AccountLogServiceImpl.java
@@ -4,6 +4,8 @@ package com.project.service;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,9 +35,9 @@ public class AccountLogServiceImpl implements AccountLogService{
 	
 
 	@Override
-	public List<AccountLog> selectAccoungLog(int accountId) {
+	public Page<AccountLog> selectAccoungLog(int accountId, Pageable page) {
 		
-		List<AccountLog> accountLogList = accountLogRep.findAllByAccountListJPQL(accountId);
+		Page<AccountLog> accountLogList = accountLogRep.findAllByAccountListJPQL(accountId, page);
 		
 		return accountLogList;
 	}

--- a/Kkabi_Backend/src/main/resources/application.properties
+++ b/Kkabi_Backend/src/main/resources/application.properties
@@ -11,9 +11,9 @@ spring.servlet.multipart.max-request-size=100MB
 
 #JPA Setting
 spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
-spring.datasource.url=jdbc:oracle:thin:@database-1.cz4gooysd78f.ap-northeast-2.rds.amazonaws.com:8080:ORCL
-spring.datasource.username=admin
-spring.datasource.password=12341234
+spring.datasource.username=c##kb
+spring.datasource.password=1234
+spring.datasource.url=jdbc:oracle:thin:@localhost:1521:XE
 
 
 

--- a/Kkabi_Backend/src/test/java/com/project/SangwooTest.java
+++ b/Kkabi_Backend/src/test/java/com/project/SangwooTest.java
@@ -7,12 +7,16 @@ import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.AccountInfo;
 import com.project.domain.AccountList;
 import com.project.domain.AccountLog;
+import com.project.domain.QuizLog;
 import com.project.domain.User;
 import com.project.repository.AccountInfoRepository;
 import com.project.repository.AccountListRepository;
@@ -61,12 +65,16 @@ class SangwooTest {
 	
 	@Test
 	void accountLogSelect() {
+		for(int j=1;j<=20;j++) {
+			accountLogRep.save(AccountLog.builder().accountLogMoney(10000)
+					.accountList(accountListRep.findById(1).orElse(null))
+					.transactionAmount(-1000)
+					.transactionReason("과자")
+					.transactionType("1").build());
+		}		
 		
-		List<AccountLog> logList = accountLogRep.findAllByAccountListJPQL(1);
-		
-		for(AccountLog l : logList) {
-			System.out.println(l);
-		}
+//		Pageable page = PageRequest.of(1, 10);
+//		Page<AccountLog> logList = accountLogRep.findAllByAccountListJPQL(1, page);
 		
 	}
 	


### PR DESCRIPTION
## 🔥 Related Issues

- close #43 

## 💙 작업 내용

- [x] ~ selectAccountLog 페이지네이션

## ✅ PR Point

> # AccountLogRepository

```
public interface AccountLogRepository extends JpaRepository<AccountLog, Integer>{
	int nowPage = 1;
	int PAGE_COUNT = 10;
	Pageable page = PageRequest.of((nowPage-1), PAGE_COUNT);
	
	@Query(value="select a from AccountLog a where a.accountList.accountId = :accountId order by a.accountLogId desc")
	Page<AccountLog> findAllByAccountListJPQL(@Param("accountId") int accountId, Pageable page);
}
```
- 1페이지 당 받아올 로그는 10개로, 로그 기록되는 역순으로 불러옵니다.

> # AccountLogServiceImpl

```
@Override
public Page<AccountLog> selectAccoungLog(int accountId, Pageable page) {
		
	Page<AccountLog> accountLogList = accountLogRep.findAllByAccountListJPQL(accountId, page);
		
	return accountLogList;
}
```
- return type을 Page로 바꾸어주었습니다.

> # AccountLogController

```
@GetMapping("/account-log")
@ApiOperation(value="내 계좌 로그 조회", notes="내역 확인 버튼을 누를 시 사용된다.")
public Page<AccountLog> selectAccountLog(int accountId, Model model, Pageable page){
		
	Page<AccountLog> accountLogList = accountLogService.selectAccoungLog(accountId, page);
		
	model.addAttribute("accountLogList", accountLogList);
		
	return accountLogList;
}
```
- controller 역시 return type을 Page로 바꾸어 준 뒤 parameter로 accountId, size, page를 받아옵니다.

## 😡 Trouble Shooting

## 👀 스크린샷 / GIF / 링크

![image](https://github.com/KB-KkaBi/KkaBi-Backend/assets/64531982/4e5ab8d6-7e05-4f4e-8888-14d6f5ce8a53)

## 📚 Reference

[최고의 페이지네이션 레퍼런스 by 팀장님](https://github.com/KB-KkaBi/KkaBi-Backend/pull/33)